### PR TITLE
switch codeql checks from go to python

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ go ]
+        language: [ Python ]
 
     steps:
       - name: Harden Runner
@@ -32,10 +32,11 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Set up Go
-        uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
+      - name: Set up Python
+        uses: actions/setup-python@dc73133d4da04e56a135ae2246682783cc7c7cb6
         with:
-          go-version: 1.20.1
+          python-version: 3.12.4
+
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v3.5.2
 


### PR DESCRIPTION
new workflows were checking for go, but should be python.